### PR TITLE
Fix string refs warning

### DIFF
--- a/src/GameEngine.js
+++ b/src/GameEngine.js
@@ -34,6 +34,7 @@ export default class GameEngine extends Component {
     this.previousTime = null;
     this.previousDelta = null;
     this.events = [];
+    this.container = new React.createRef();
   }
 
   async componentDidMount() {
@@ -146,7 +147,7 @@ export default class GameEngine extends Component {
   render() {
     return (
       <div
-        ref={"container"}
+        ref={this.container}
         style={{ ...css.container, ...this.props.style }}
         className={this.props.className}
         tabIndex={0}


### PR DESCRIPTION
Warning: String refs are a source of potential bugs and should be avoided. We recommend using useRef() or createRef() instead.
Refactor string ref to React.createRef