### PR TITLE
Fix UNSAFE_componentWillReceiveProps warning

### DIFF
--- a/src/GameEngine.js
+++ b/src/GameEngine.js
@@ -56,9 +56,9 @@ export default class GameEngine extends Component {
     this.timer.unsubscribe(this.updateHandler);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.running !== this.props.running) {
-      if (nextProps.running) this.start();
+  componentDidUpdate(prevProps) {
+    if (prevProps.running !== this.props.running) {
+      if (this.props.running) this.start();
       else this.stop();
     }
   }


### PR DESCRIPTION
Warning: Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code.
Refactor UNSAFE_componentWillReceiveProps to componentDidUpdate